### PR TITLE
Inheritance customized `docs_url` and `redoc_url`

### DIFF
--- a/fastapi_versioning/versioning.py
+++ b/fastapi_versioning/versioning.py
@@ -35,6 +35,8 @@ def VersionedFastAPI(
 ) -> FastAPI:
     parent_app = FastAPI(
         title=app.title,
+        docs_url=app.docs_url,
+        redoc_url=app.redoc_url,
         **kwargs,
     )
     version_route_mapping: Dict[Tuple[int, int], List[APIRoute]] = defaultdict(
@@ -57,6 +59,8 @@ def VersionedFastAPI(
             title=app.title,
             description=app.description,
             version=semver,
+            docs_url=app.docs_url,
+            redoc_url=app.redoc_url
         )
         for route in version_route_mapping[version]:
             for method in route.methods:
@@ -80,6 +84,8 @@ def VersionedFastAPI(
             title=app.title,
             description=app.description,
             version=semver,
+            docs_url=app.docs_url,
+            redoc_url=app.redoc_url
         )
         for route in unique_routes.values():
             versioned_app.router.routes.append(route)


### PR DESCRIPTION
Inheritance customized `docs_url` and `redoc_url` endpoint from parent FastAPI instance.
sometimes I need to customized the endpoint string, as https://github.com/tiangolo/fastapi/discussions/2655#discussioncomment-324460 mentioned.
